### PR TITLE
Modify play button placement and reduce no of `playerState` arguments in JSX elements

### DIFF
--- a/src/Camera.js
+++ b/src/Camera.js
@@ -16,16 +16,15 @@ import AwesomeButtonRick from 'react-native-really-awesome-button/src/themes/ric
 
 export default function VideoRecorder(props) {
   let cameraRef;
-
-  const { state, updateState, curScreenNum, updateClipUri, fileUri,
-    videoDuration, updateVideoDuration } = props;
+  const { updatePlayersState, curScreenNum, playersState, updateZubVideoUrl } = props;
+  const state = playersState[curScreenNum].state;
 
   React.useEffect(() => {
     async function startRecording() {
       try {
         const options = { path: RNFS.CachesDirectoryPath + '/video_' + curScreenNum + '.mp4' };
         const { uri } = await cameraRef.recordAsync(options);
-        updateClipUri(uri);
+        updatePlayersState('filePath', uri);
       } catch (ex) {
         console.log(ex);
       }
@@ -60,12 +59,10 @@ export default function VideoRecorder(props) {
         (state === PlayerState.PREVIEW || state === PlayerState.PLAYING ||
           state === PlayerState.SAVED) &&
         <VideoPlayer
-          state={state}
-          fileUri={fileUri}
-          fileNum={curScreenNum}
-          updateState={updateState}
-          videoDuration={videoDuration}
-          updateVideoDuration={updateVideoDuration}
+          playersState={playersState}
+          updatePlayersState={updatePlayersState}
+          updateZubVideoUrl={updateZubVideoUrl}
+          curScreenNum={curScreenNum}
         />
       }
       {

--- a/src/Player.js
+++ b/src/Player.js
@@ -14,33 +14,34 @@ import { RNFFmpeg } from 'react-native-ffmpeg';
 import { PlayerState } from './Constants';
 import RNFS from 'react-native-fs';
 import AwesomeButtonCartman from 'react-native-really-awesome-button/src/themes/cartman';
+import AwesomeButtonRick from 'react-native-really-awesome-button/src/themes/rick';
 import { requestMicPermission, deleteMediaFile, moveMediaFile } from './Utils';
+import { mergeVideos } from './Utils';
 
 export default function VideoPlayer(props) {
-  const { fileNum, fileUri, state, updateState, videoDuration,
-    updateVideoDuration } = props;
+  const { curScreenNum, updatePlayersState, playersState, updateZubVideoUrl } = props;
+  const state = playersState[curScreenNum].state,
+    filePath = playersState[curScreenNum].filePath;
 
   React.useEffect(() => {
     async function startAudioRecording() {
       let options = {};
-
       if (Platform.OS === 'android') {
         // We need to specify audio codec as AAC for audio in Android
         options = {
           encoder: 3,    // AAC (https://developer.android.com/reference/android/media/MediaRecorder.AudioEncoder#AAC)
         };
-
         await requestMicPermission();
       }
 
-      await SoundRecorder.start(RNFS.CachesDirectoryPath + '/audio_' + fileNum + '.mp4', options)
+      await SoundRecorder.start(RNFS.CachesDirectoryPath + '/audio_' + curScreenNum + '.mp4', options)
       .then(function() {
         console.log('Started Audio Recording');
       });
     }
 
     async function stopAudioRecording() {
-      const destPath = RNFS.CachesDirectoryPath + '/output_' + fileNum + '.mp4';
+      const destPath = RNFS.CachesDirectoryPath + '/output_' + curScreenNum + '.mp4';
       await deleteMediaFile(destPath);
 
       await SoundRecorder.stop()
@@ -48,11 +49,11 @@ export default function VideoPlayer(props) {
         console.log('Stopped audio recording, audio file saved at: ' + audio.path);
 
         //Combine audio and video
-        RNFFmpeg.execute('-i ' + fileUri + ' -i ' + audio.path + ' -c copy ' + destPath, ' ')
+        RNFFmpeg.execute('-i ' + filePath + ' -i ' + audio.path + ' -c copy ' + destPath, ' ')
         .then(function(media) {
           console.log('FFmpeg process exited with rc ' + media.rc);
-          deleteMediaFile(fileUri);
-          moveMediaFile(destPath, fileUri);
+          deleteMediaFile(filePath);
+          moveMediaFile(destPath, filePath);
         });
       }).catch(function(error) {
         console.log('An error occured while stoping the recording: ' + error);
@@ -74,26 +75,38 @@ export default function VideoPlayer(props) {
     }
 
     return stopAudioRecording;
-  }, [state, updateState, videoDuration, updateVideoDuration]);
+  }, [state, updatePlayersState]);
 
   return (
     <View style={styles.videoContainer}>
       <Video
-        source={{ uri: fileUri }}
-        // TODO: We will use this eventually, keeping them here so we remember ;-)
-        // ref={(ref) => {
-        //   this.player = ref;
-        // }}
-        // onBuffer={this.onBuffer}                // Callback when remote video is buffering
-        // onEnd={this.onEnd}                      // Callback when playback finishes
-        // onError={this.videoError}
+        source={{ uri: filePath }}
         muted={false}
         style={styles.backgroundVideo}
         onLoad={(data) => {
-          updateVideoDuration(Math.round(data.duration));
+          updatePlayersState('videoDuration', Math.round(data.duration));
         }}
       />
-        <View style={styles.box}>
+
+      {
+        playersState[0].filePath !== '' && playersState[1].filePath !== '' &&
+        playersState[2].filePath !== '' &&
+        <View style={styles.mergeButtonBox}>
+          <AwesomeButtonRick
+            borderRadius={50}
+            height={50}
+            stretch={true}
+            textSize={30}
+            type="anchor"
+            onPress={() => {
+              mergeVideosAndUpdateUrl();
+          }}>
+            ✓
+          </AwesomeButtonRick>
+        </View>
+      }
+
+      <View style={styles.box}>
         <AwesomeButtonCartman
           borderRadius={10}
           height={50}
@@ -101,8 +114,7 @@ export default function VideoPlayer(props) {
           raiseLevel={5}
           type="secondary"
           onPress={() => {
-            let newState = state === PlayerState.PLAYING ? PlayerState.SAVED : PlayerState.PLAYING;
-            updateState(newState);
+            updatePlayersState('state', state);
           }}
           title="Record">
           {
@@ -112,6 +124,13 @@ export default function VideoPlayer(props) {
         </View>
     </View>
   );
+
+  async function mergeVideosAndUpdateUrl() {
+    let merged_video = await mergeVideos();
+    if (merged_video) {
+      updateZubVideoUrl(merged_video);
+    }
+  }
 }
 
 const styles = StyleSheet.create({
@@ -132,6 +151,12 @@ const styles = StyleSheet.create({
   box: {
     position: 'absolute',
     bottom: 10,
+    left: 10,
+    width: '22%',
+  },
+  mergeButtonBox: {
+    position: 'absolute',
+    top: 10,
     left: 10,
     width: '22%',
   },

--- a/src/ProgressBar.js
+++ b/src/ProgressBar.js
@@ -14,8 +14,10 @@ import { PlayerState } from './Constants';
 export default function ProgressBar(props) {
   const maxClipSize = 40;
   const [count, setCount] = React.useState(0);
-  const { state, updateState, videoDuration, updateVideoDuration } = props;
+  const { curScreenNum, playersState, updatePlayersState } = props;
   const [ clipSize, setClipSize ] = React.useState(maxClipSize);
+  const videoDuration = playersState[curScreenNum].videoDuration,
+    state = playersState[curScreenNum].state;
 
   React.useEffect(() => {
     let interval = null;
@@ -33,7 +35,7 @@ export default function ProgressBar(props) {
       interval = setInterval(() => {
         if (count >= clipSize) {
           clearInterval(interval);
-          updateState();
+          updatePlayersState('state', state);
         } else {
           setCount(count + 1);
         }
@@ -41,7 +43,7 @@ export default function ProgressBar(props) {
     }
 
     return () => interval && clearInterval(interval);
-  }, [state, updateState, count, clipSize, updateVideoDuration]);
+  }, [count, clipSize]);
 
   return (
     <View style={styles.progressBarContainer}>


### PR DESCRIPTION
Some changes addressed in this pull request for https://github.com/srish/zub/issues/18: 
* Removed the green tick button and moved it to the preview screen above Record Audio button. Green button for now is a tick (✓)
* Done a bit of code refactoring to reduce the number of `playersState` arguments we are passing in JSX elements. The changes ensure that if JSX element has the `playersState` argument, we don't pass any of its child properties.
* Some logic around calling `updatePlayersState` (previously `updatePlayerRecordingState`). In some places, it was called with an updated state value. These changes ensure that the particular logic is taken care when `decideNextState` gets called.
